### PR TITLE
Fix "no repositories found" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_HELM_IMAGE=alpine/helm:3.2.0
+ARG ALPINE_HELM_IMAGE=alpine/helm:3.4.2
 
 FROM $ALPINE_HELM_IMAGE
 LABEL maintainer "Yann David (@Typositoire) <davidyann88@gmail>"

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -226,6 +226,7 @@ setup_repos() {
     done
   fi
 
+  $helm_bin repo add stable https://charts.helm.sh/stable
   $helm_bin repo update
 }
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -40,6 +40,7 @@ generate_awscli_kubeconfig() {
   local aws_eks_cluster_name
   aws_eks_cluster_name="$(jq -r '.source.aws_eks_cluster_name // ""' < "$payload")"
   aws eks update-kubeconfig --name $aws_eks_cluster_name
+  chmod 600 "/root/.kube/config"
 }
 
 generate_aws_kubeconfig() {
@@ -80,6 +81,7 @@ EOF
     kubectl config unset users
 
     cat "$tmpfile" > $kubeconfig_file
+    chmod 600 $kubeconfig_file
   fi
 }
 
@@ -93,6 +95,7 @@ setup_kubernetes() {
   use_awscli_eks_auth="$(jq -r '.source.use_awscli_eks_auth // "false"' < "$payload")"
   if [ -f "$absolute_kubeconfig_path" ]; then
     cp "$absolute_kubeconfig_path" "/root/.kube/config"
+    chmod 600 "/root/.kube/config"
   else
     # shortcut using awscli for eks
     if [ "$use_awscli_eks_auth" == "true" ]; then


### PR DESCRIPTION
dcb76d3 removed "$helm_bin repo add stable https://kubernetes-charts.storage.googleapis.com"

In that case, it is possible to end up without any repositories, and
the helm update then fails with

    Error: no repositories found. You must add one before updating

As stated on https://helm.sh/blog/new-location-stable-incubator-charts/
and seen in
https://github.com/Typositoire/concourse-helm3-resource/commit/8f414ec7f712c3f4c1a6ead76134225c2a3cb5ca,
instead of removing the line, the repository URL can be changed to

    https://charts.helm.sh/stable