### PR TITLE
Fix "no repositories found" error

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -226,6 +226,7 @@ setup_repos() {
     done
   fi
 
+  $helm_bin repo add stable https://charts.helm.sh/stable
   $helm_bin repo update
 }
 


### PR DESCRIPTION
dcb76d3 removed "$helm_bin repo add stable https://kubernetes-charts.storage.googleapis.com"

In that case, it is possible to end up without any repositories, and
the helm update then fails with

    Error: no repositories found. You must add one before updating

As stated on https://helm.sh/blog/new-location-stable-incubator-charts/
and seen in
https://github.com/Typositoire/concourse-helm3-resource/commit/8f414ec7f712c3f4c1a6ead76134225c2a3cb5ca,
instead of removing the line, the repository URL can be changed to

    https://charts.helm.sh/stable