### PR TITLE
Fix missing output when no release has been made

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_HELM_IMAGE=alpine/helm:3.2.0
+ARG ALPINE_HELM_IMAGE=alpine/helm:3.4.2
 
 FROM $ALPINE_HELM_IMAGE
 LABEL maintainer "Yann David (@Typositoire) <davidyann88@gmail>"

--- a/assets/check
+++ b/assets/check
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-set -o pipefail
 
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -226,6 +226,7 @@ setup_repos() {
     done
   fi
 
+  $helm_bin repo add stable https://charts.helm.sh/stable
   $helm_bin repo update
 }
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -40,6 +40,7 @@ generate_awscli_kubeconfig() {
   local aws_eks_cluster_name
   aws_eks_cluster_name="$(jq -r '.source.aws_eks_cluster_name // ""' < "$payload")"
   aws eks update-kubeconfig --name $aws_eks_cluster_name
+  chmod 600 "/root/.kube/config"
 }
 
 generate_aws_kubeconfig() {
@@ -80,6 +81,7 @@ EOF
     kubectl config unset users
 
     cat "$tmpfile" > $kubeconfig_file
+    chmod 600 $kubeconfig_file
   fi
 }
 
@@ -93,6 +95,7 @@ setup_kubernetes() {
   use_awscli_eks_auth="$(jq -r '.source.use_awscli_eks_auth // "false"' < "$payload")"
   if [ -f "$absolute_kubeconfig_path" ]; then
     cp "$absolute_kubeconfig_path" "/root/.kube/config"
+    chmod 600 "/root/.kube/config"
   else
     # shortcut using awscli for eks
     if [ "$use_awscli_eks_auth" == "true" ]; then


### PR DESCRIPTION
Commit 05ed406 added "set -o pipefail" in `assets/check`, but this creates a tiny side effect:

When no revisions exist yet, "grep -i 'deployed'" returns 1, and with pipefail enabled, the whole pipe returns 1. At this point, the script immediately exits (due to "set -e"), and the output in line 57 will never happen, confusing the user.